### PR TITLE
One last try using Dr C's yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,25 @@
+#Got a new script! Snagged this bad boy from
+#https://github.com/pestrada/android-tdd-playground/blob/master/.travis.yml
 language: android
 jdk: oraclejdk8
+sudo: false
 
-env:
- global:
-    - ANDROID_API_LEVEL=27
-    - ANDROID_BUILD_TOOLS_VERSION=26.1.1
-#The BuildTools version used by your project
-    - build-tools-$ANDROID_BUILD_TOOLS_VERSION
-    - extra
+android:
+ components:
+   - platform-tools
+   - tools
+   - build-tools-29.0.2
+   - android-22
+   - android-29
+   - android-24
+   - sys-img-armeabi-v7a-android-22
+   - sys-img-
+   - extra-android-m2repository
 
-#The SDK version used to compile your project
-    - android-$ANDROID_API_LEVEL
-# Specify at least one system image,
-# if you need to run emulator(s) during your tests
-    - sys-img-x86-android-27
-    - sys-img-armeabi-v7a-android-17
-licenses:
-    - 'android-sdk-preview-license-52d11cd2'
-    - 'android-sdk-license-.+'
-    - 'google-gdk-license-.+'
-    - 'build-tools-license-.+'
-
+before_script:
+ # Create and start emulator
+ - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+ - emulator -avd test -no-skin -no-audio -no-window &
+ - android-wait-for-emulator
+ - adb shell input keyevent 82 &
+script: ./gradlew connectedAndroidTest


### PR DESCRIPTION
Old file: language: android
jdk: oraclejdk8

env:
 global:
    - ANDROID_API_LEVEL=27
    - ANDROID_BUILD_TOOLS_VERSION=26.1.1
#The BuildTools version used by your project
    - build-tools-$ANDROID_BUILD_TOOLS_VERSION
    - extra

#The SDK version used to compile your project
    - android-$ANDROID_API_LEVEL
# Specify at least one system image,
# if you need to run emulator(s) during your tests
    - sys-img-x86-android-27
    - sys-img-armeabi-v7a-android-17
licenses:
    - 'android-sdk-preview-license-52d11cd2'
    - 'android-sdk-license-.+'
    - 'google-gdk-license-.+'
    - 'build-tools-license-.+'